### PR TITLE
fixed from PVS-Studio:

### DIFF
--- a/NppQCP.cpp
+++ b/NppQCP.cpp
@@ -351,10 +351,12 @@ LRESULT CALLBACK MessageWindowWinproc(HWND hwnd, UINT message, WPARAM wparam, LP
 		case WM_QCP_START_SCREEN_PICKER:
 		{
 			::SetWindowPos(nppData._nppHandle, HWND_BOTTOM, 0,0,0,0, SWP_NOMOVE|SWP_NOSIZE);
+			break;
 		}
 		case WM_QCP_END_SCREEN_PICKER:
 		{
 			::ShowWindow(nppData._nppHandle, SW_SHOW);
+			break;
 		}
 		default:
 		{
@@ -594,7 +596,9 @@ bool CheckSelectionForBracketColor(const HWND h_scintilla, const int start, cons
 			}
 			else {
 				// close bracket ')' found, cut the end and continue
-				buff[i + 1] = '\0';
+				if (i < buff_len-1) buff[i + 1] = '\0';
+				else buff[i] = '\0';
+
 				close_pos += i;
 				break;
 			}
@@ -942,7 +946,9 @@ void FindBracketColor(const HWND h_scintilla, const int start_position, const in
 				}
 				else {
 					// close bracket ')' found, cut the end and continue
-					buff[i + 1] = '\0';
+					if (i < buff_length - 1) buff[i + 1] = '\0';
+					else buff[i] = '\0';
+
 					is_valid = true;
 					break;
 				}

--- a/QuickColorPicker/ColorPicker.cpp
+++ b/QuickColorPicker/ColorPicker.cpp
@@ -542,7 +542,7 @@ void ColorPicker::DisplayNewColor(RGBAColor color){
 
 	// output
 	wchar_t output[80];
-	swprintf(output, sizeof(output), L"#%hs / HSLA(%d,%d%%,%d%%,%.2g)", hex, round(hsl.h), round(hsl.s * 100), round(hsl.l * 100), hsl.a);
+	swprintf(output, sizeof(output)/sizeof(wchar_t), L"#%hs / HSLA(%d,%d%%,%d%%,%.2g)", hex, round(hsl.h), round(hsl.s * 100), round(hsl.l * 100), hsl.a);
 	::SetDlgItemText(_color_popup, IDC_COLOR_TEXT, output);
 
 	PaintColorCompareSwatch();
@@ -562,7 +562,6 @@ void ColorPicker::GenerateColorPaletteData(float alpha){
 
 		int t0 = (i-RECENT_ZONE_COLUMN)*0x11;
 		if (t0 < 0) t0 = 0;
-		if (t0 > 0xFF) t0 = 0xFF;
 	
 		int t1 = t0 + 0x02;
 		int t1s = t1 - 0x0F;


### PR DESCRIPTION
V512 A call of the 'swprintf' function will lead to overflow of the buffer 'output'. colorpicker.cpp 545
V575 The number of processed elements should be passed to the 'swprintf' function as the second argument instead of buffer's size in bytes. colorpicker.cpp 545
V547 Expression 't0 > 0xFF' is always false. colorpicker.cpp 565
V557 Array overrun is possible. The value of 'i + 1' index could reach 50. nppqcp.cpp 597, 945
V796 It is possible that 'break' statement is missing in switch statement. nppqcp.cpp 354